### PR TITLE
added method to set parser-options

### DIFF
--- a/lessc.inc.php
+++ b/lessc.inc.php
@@ -22,6 +22,7 @@ class lessc{
 	protected $allParsedFiles = array();
 	protected $libFunctions = array();
 	protected $registeredVars = array();
+	protected $options = array();
 	private $formatterName;
 
 	public function __construct($lessc=null, $sourceName=null) {}
@@ -62,8 +63,18 @@ class lessc{
 		unset( $this->registeredVars[$name] );
 	}
 
+	public function setOptions($options){
+		foreach( $options as $name => $value ){
+			$this->setOption( $name, $value);
+		}
+	}
+	
+	public function setOption($name, $value){
+		$this->options[$name] = $value;
+	}
+	
 	public function parse($buffer, $presets = array()){
-		$options = array();
+		$options = $this->options;
 		$this->setVariables($presets);
 
 		switch($this->formatterName){


### PR DESCRIPTION
As I've written in my original pull-request to the other github-project (https://github.com/oyejorge/less.php/pull/187), I updated the usage of the options-array due to the fact, that the options are not used correctly (always uses a new, empty array) in the ``parse()``-method.

With this functionality, the options can be set and used for parsing:
```
$lc = new \lessc();
$lc->setOptions(array('relativeUrls' => false));
$content = $lc->parse($lessContent);
```
This gives you the possibility to inject the options to the parser, which is already implemented. By using the parser-class directly, the same options could be set as follows:
```
$parser = new \Less_Parser(array('relativeUrls' => false))
```
